### PR TITLE
create a separate Upload schema

### DIFF
--- a/components/Map.yaml
+++ b/components/Map.yaml
@@ -11,6 +11,9 @@ schemas:
       createdAt:
       updatedAt:
       deletedAt:
+      uploadedBy:
+        type: string
+        description: Auth0 id of the current user
       upload:
         type: object
         $ref: 'https://github.com/fantasmoio/api-spec/components/Upload.yaml'

--- a/components/Map.yaml
+++ b/components/Map.yaml
@@ -11,6 +11,9 @@ schemas:
       createdAt:
       updatedAt:
       deletedAt:
+      upload:
+        type: object
+        $ref: 'https://github.com/fantasmoio/api-spec/components/Upload.yaml'
       pointclouds:
         type: array
         items:

--- a/components/PipelineEvent.yaml
+++ b/components/PipelineEvent.yaml
@@ -1,0 +1,15 @@
+schemas:
+  PipelineEvent:
+    type: object
+    required:
+      - timestamp
+      - message
+      - step
+    properties:
+      timestamp:
+        type: string
+        format: date-time
+        description: Creation time in seconds since the Unix epoch
+      message:
+        type: string
+        description: describes which step in the pipeline has been reached

--- a/components/Upload.yaml
+++ b/components/Upload.yaml
@@ -1,0 +1,24 @@
+schemas:
+  Upload:
+    required:
+      - files
+      - status
+    properties:
+      status:
+        type: string
+        description: status of map upload in the processing pipeline
+      errorMessage:
+        type: string
+        description: if the map upload fails in the pipeline, the error will be reported here
+      files:
+        type: array
+        items:
+          required:
+            - filename
+          properties:
+            filename:
+              type: string
+              description: plain filename including extension
+            status:
+              type: string
+              description: verification status of file. starts off as 'incomplete' before it has been uploaded

--- a/components/Upload.yaml
+++ b/components/Upload.yaml
@@ -7,9 +7,6 @@ schemas:
       status:
         type: string
         description: status of map upload in the processing pipeline
-      errorMessage:
-        type: string
-        description: if the map upload fails in the pipeline, the error will be reported here
       files:
         type: array
         items:
@@ -22,3 +19,16 @@ schemas:
             status:
               type: string
               description: verification status of file. starts off as 'incomplete' before it has been uploaded
+      error:
+        type: object
+        description: if the map upload fails in the pipeline, the error will be reported here
+        properties:
+          name:
+            type: string
+            description: short error name
+          message:
+            type: string
+            description: verbose error message
+          occuredAt:
+            type: date-time
+            description: time error occured in Unix Epoch seconds

--- a/components/Upload.yaml
+++ b/components/Upload.yaml
@@ -32,3 +32,7 @@ schemas:
           occuredAt:
             type: date-time
             description: time error occured in Unix Epoch seconds
+      pipelineEvents:
+        type: array
+        items:
+          $ref: 'https://github.com/fantasmoio/api-spec/components/PipelineEvent.yaml'


### PR DESCRIPTION
Prior to this, we considered the 'Map' object to be an upload. But semantically they are different and have a belongs-to type of relationship. In this pull request, we are moving Upload to be it's own top-level object of a map, with it's own schema

The Upload object has it's own status, as well as an errorMessage field that holds a description of any pipeline failures. It has a similar 'files' field to the previous upload top-level object.